### PR TITLE
feat(ui): apply Latitud brand identity across the application

### DIFF
--- a/artifacts/latitud/public/assets/logo.svg
+++ b/artifacts/latitud/public/assets/logo.svg
@@ -1,0 +1,19 @@
+<svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Gold arc: upper ~270° of ring (CCW from lower-right to lower-left) -->
+  <path d="M 90 90 A 42 42 0 1 0 30 90"
+        stroke="#C4973A" stroke-width="10" fill="none" stroke-linecap="butt"/>
+  <!-- Steel blue arc: lower ~90° of ring (through the south) -->
+  <path d="M 30 90 A 42 42 0 0 0 90 90"
+        stroke="#4E80A4" stroke-width="10" fill="none" stroke-linecap="butt"/>
+  <!-- Cardinal notches (white cuts at N, E, S, W) -->
+  <rect x="55" y="13"  width="10" height="10" fill="white"/>
+  <rect x="97" y="55"  width="10" height="10" fill="white"/>
+  <rect x="55" y="97"  width="10" height="10" fill="white"/>
+  <rect x="13" y="55"  width="10" height="10" fill="white"/>
+  <!-- Compass needle: lozenge rotated 35° CW = pointing NE -->
+  <g transform="translate(60,60) rotate(35)">
+    <path d="M 0 -46 L 8 2 L 0 22 L -8 2 Z" fill="#1C3456"/>
+  </g>
+  <!-- Center hub -->
+  <circle cx="60" cy="60" r="5" fill="white" stroke="#1C3456" stroke-width="2"/>
+</svg>

--- a/artifacts/latitud/public/favicon.svg
+++ b/artifacts/latitud/public/favicon.svg
@@ -1,3 +1,9 @@
-<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="180" height="180" rx="36" fill="#FF3C00"/>
+<svg viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="180" rx="36" fill="#1C3456"/>
+  <path d="M 135 135 A 63 63 0 1 0 45 135" stroke="#C4973A" stroke-width="14" fill="none" stroke-linecap="butt"/>
+  <path d="M 45 135 A 63 63 0 0 0 135 135" stroke="#4E80A4" stroke-width="14" fill="none" stroke-linecap="butt"/>
+  <g transform="translate(90,90) rotate(35)">
+    <path d="M 0 -69 L 12 3 L 0 33 L -12 3 Z" fill="white"/>
+  </g>
+  <circle cx="90" cy="90" r="7.5" fill="#1C3456" stroke="white" stroke-width="3"/>
 </svg>

--- a/artifacts/latitud/src/components/LanguageSwitcher.tsx
+++ b/artifacts/latitud/src/components/LanguageSwitcher.tsx
@@ -18,7 +18,7 @@ export function LanguageSwitcher() {
 
   return (
     <div className="fixed top-4 right-4 z-50 flex items-center gap-1 p-1 rounded-xl backdrop-blur-sm"
-      style={{ background: 'rgba(15,23,42,0.55)' }}
+      style={{ background: 'rgba(28,52,86,0.55)' }}
     >
       {LANGUAGES.map(({ code, flag, label }) => {
         const isActive = active === code;
@@ -29,9 +29,9 @@ export function LanguageSwitcher() {
             aria-label={`Switch to ${label}`}
             className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold transition-all duration-150 select-none"
             style={{
-              background: isActive ? '#fff' : 'transparent',
-              color: isActive ? '#0f172a' : 'rgba(255,255,255,0.5)',
-              boxShadow: isActive ? '0 1px 6px rgba(0,0,0,0.18)' : 'none',
+              background: isActive ? '#C4973A' : 'transparent',
+              color: isActive ? '#fff' : 'rgba(255,255,255,0.55)',
+              boxShadow: isActive ? '0 1px 6px rgba(196,151,58,0.30)' : 'none',
             }}
           >
             <span>{flag}</span>

--- a/artifacts/latitud/src/domains/map/components/DrawingTool.tsx
+++ b/artifacts/latitud/src/domains/map/components/DrawingTool.tsx
@@ -1,6 +1,7 @@
 import { Pencil, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useMapStore } from "@/domains/map/store/map.store";
+import { B } from "./sidebarTheme";
 
 export function DrawingTool() {
   const { t } = useTranslation();
@@ -32,10 +33,10 @@ export function DrawingTool() {
         data-testid="button-drawing-tool"
         className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-semibold transition-all duration-150"
         style={{
-          background: isDrawingMode ? "#6366f1" : "#1e293b",
-          color: isDrawingMode ? "#fff" : "#94a3b8",
-          border: isDrawingMode ? "1px solid #6366f1" : "1px solid #334155",
-          boxShadow: isDrawingMode ? "0 0 0 3px rgba(99,102,241,0.25)" : "none",
+          background:  isDrawingMode ? B.gold : B.surface,
+          color:       isDrawingMode ? "#fff" : B.navy,
+          border:      isDrawingMode ? `1px solid ${B.gold}` : `1px solid ${B.border}`,
+          boxShadow:   isDrawingMode ? `0 0 0 3px rgba(196,151,58,0.20)` : "none",
         }}
       >
         <Pencil className="w-3.5 h-3.5" />
@@ -48,9 +49,9 @@ export function DrawingTool() {
           data-testid="button-clear-polygon"
           className="w-full flex items-center justify-center gap-2 py-2 rounded-xl text-xs font-semibold transition-all duration-150"
           style={{
-            background: "transparent",
-            color: "#64748b",
-            border: "1px solid #334155",
+            background: B.surface,
+            color:      B.navy,
+            border:     `1px solid ${B.border}`,
           }}
         >
           <X className="w-3 h-3" />
@@ -59,7 +60,7 @@ export function DrawingTool() {
       )}
 
       {isDrawingMode && (
-        <p className="text-xs text-center text-indigo-400 animate-pulse">
+        <p className="text-xs text-center animate-pulse" style={{ color: B.gold }}>
           Click and drag to draw an area
         </p>
       )}

--- a/artifacts/latitud/src/domains/map/components/LayersControl.tsx
+++ b/artifacts/latitud/src/domains/map/components/LayersControl.tsx
@@ -2,6 +2,7 @@ import { Car, Train, Bike, Layers } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useMapStore } from "@/domains/map/store/map.store";
 import type { LayerType } from "@/domains/map/hooks/useMapLayers";
+import { B } from "./sidebarTheme";
 
 const LAYERS: { value: LayerType; tKey: string; Icon: React.ElementType }[] = [
   { value: "traffic",   tKey: "layers.traffic",  Icon: Car   },
@@ -20,7 +21,7 @@ export function LayersControl() {
 
   return (
     <div>
-      <div className="flex items-center gap-2 text-slate-400 text-xs font-semibold uppercase tracking-widest mb-3">
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest mb-3" style={{ color: B.faint }}>
         <Layers className="w-3.5 h-3.5" />
         <span>{t("sidebar.traffic_info")}</span>
       </div>
@@ -34,15 +35,15 @@ export function LayersControl() {
               data-testid={`layer-${value}`}
               className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-all duration-150"
               style={{
-                background: active ? "rgba(14,165,233,0.15)" : "#1e293b",
-                color: active ? "#0ea5e9" : "#94a3b8",
-                border: active ? "1px solid rgba(14,165,233,0.4)" : "1px solid #334155",
+                background: active ? `rgba(78,128,164,0.10)` : B.surface,
+                color:      active ? B.steel : B.navy,
+                border:     active ? `1px solid rgba(78,128,164,0.35)` : `1px solid ${B.border}`,
               }}
             >
               <Icon className="w-3.5 h-3.5 shrink-0" />
               <span className="font-medium">{t(tKey)}</span>
               {active && (
-                <span className="ml-auto w-1.5 h-1.5 rounded-full bg-sky-400" />
+                <span className="ml-auto w-1.5 h-1.5 rounded-full" style={{ background: B.steel }} />
               )}
             </button>
           );
@@ -50,7 +51,7 @@ export function LayersControl() {
       </div>
 
       {activeLayer === "transit" && (
-        <p className="text-xs text-amber-400 mt-2 leading-relaxed">
+        <p className="text-xs mt-2 leading-relaxed text-amber-600">
           Public transit data may be limited for this region.
         </p>
       )}

--- a/artifacts/latitud/src/domains/map/components/MapSidebar.tsx
+++ b/artifacts/latitud/src/domains/map/components/MapSidebar.tsx
@@ -8,6 +8,9 @@ import { LayersControl } from "./LayersControl";
 import { NearbyPlaces } from "./NearbyPlaces";
 import { useFilters } from "@/domains/search/hooks/useFilters";
 
+import { B } from "./sidebarTheme";
+export { B };
+
 const BEDROOM_OPTIONS = [
   { value: 0, labelKey: "filters.any" },
   { value: 1, label: "1+" },
@@ -48,8 +51,8 @@ function PriceRangeSlider() {
   return (
     <div>
       <div className="flex justify-between text-xs mb-2">
-        <span className="text-slate-500">R$0</span>
-        <span className="text-slate-200 font-medium">
+        <span style={{ color: B.faint }}>R$0</span>
+        <span style={{ color: B.navy }} className="font-medium">
           {currentMax >= max ? t("filters.any") : formatLabel(currentMax)}
         </span>
       </div>
@@ -63,7 +66,7 @@ function PriceRangeSlider() {
         data-testid="slider-price"
         className="w-full h-1.5 rounded-full appearance-none cursor-pointer"
         style={{
-          background: `linear-gradient(to right, #0ea5e9 0%, #0ea5e9 ${pct}%, #334155 ${pct}%, #334155 100%)`,
+          background: `linear-gradient(to right, ${B.steel} 0%, ${B.steel} ${pct}%, ${B.border} ${pct}%, ${B.border} 100%)`,
         }}
       />
     </div>
@@ -71,7 +74,7 @@ function PriceRangeSlider() {
 }
 
 function Divider() {
-  return <div className="h-px" style={{ background: "#1e293b" }} />;
+  return <div className="h-px" style={{ background: B.border }} />;
 }
 
 export function MapSidebar() {
@@ -80,38 +83,33 @@ export function MapSidebar() {
   const { activeFilterCount } = useFilters();
 
   const PROPERTY_TYPES: { value: PropertyType | "all"; tKey: string }[] = [
-    { value: "all", tKey: "filters.all_types" },
-    { value: "apartment", tKey: "filters.apartment" },
-    { value: "house", tKey: "filters.house" },
+    { value: "all",        tKey: "filters.all_types"  },
+    { value: "apartment",  tKey: "filters.apartment"  },
+    { value: "house",      tKey: "filters.house"      },
     { value: "commercial", tKey: "filters.commercial" },
-    { value: "office", tKey: "filters.office" },
+    { value: "office",     tKey: "filters.office"     },
   ];
 
   return (
     <aside
       className="flex flex-col h-full overflow-y-auto"
-      style={{ background: "#0f172a", color: "#e2e8f0" }}
+      style={{ background: B.bg, color: B.navy }}
       data-testid="sidebar"
     >
       {/* Logo */}
-      <div className="px-6 pt-6 pb-5 border-b border-slate-700/60">
-        <div className="flex items-center gap-2">
-          <div
-            className="w-7 h-7 rounded-lg flex items-center justify-center"
-            style={{ background: "#0ea5e9" }}
-          >
-            <span className="text-white font-black text-sm leading-none">L</span>
-          </div>
-          <span className="text-xl font-bold tracking-tight text-white">Latitud</span>
+      <div className="px-6 pt-6 pb-5" style={{ borderBottom: `1px solid ${B.border}` }}>
+        <div className="flex items-center gap-2.5">
+          <img src="/assets/logo.svg" alt="Latitud" className="w-8 h-8" />
+          <span className="text-xl font-bold tracking-tight" style={{ color: B.navy }}>Latitud</span>
         </div>
-        <p className="text-slate-400 text-xs mt-1.5">
+        <p className="text-xs mt-1.5" style={{ color: B.faint }}>
           {filteredListings.length} {t("stats.properties_found")}
         </p>
       </div>
 
       {/* Transaction toggle */}
-      <div className="px-6 py-5 border-b border-slate-700/60">
-        <div className="flex rounded-xl p-1" style={{ background: "#1e293b" }}>
+      <div className="px-6 py-5" style={{ borderBottom: `1px solid ${B.border}` }}>
+        <div className="flex rounded-xl p-1" style={{ background: B.element }}>
           {(["rent", "sale"] as const).map((type) => (
             <button
               key={type}
@@ -119,8 +117,8 @@ export function MapSidebar() {
               data-testid={`toggle-${type}`}
               className="flex-1 py-2 text-sm font-semibold rounded-lg transition-all duration-150"
               style={{
-                background: activeFilters.transactionType === type ? "#0ea5e9" : "transparent",
-                color: activeFilters.transactionType === type ? "#fff" : "#94a3b8",
+                background: activeFilters.transactionType === type ? B.steel : "transparent",
+                color:      activeFilters.transactionType === type ? "#fff" : B.navy,
               }}
             >
               {type === "rent" ? t("sidebar.rent") : t("sidebar.sale")}
@@ -134,14 +132,14 @@ export function MapSidebar() {
 
         {/* Filters header with badge */}
         <div className="flex items-center gap-2">
-          <SlidersHorizontal className="w-3.5 h-3.5 text-slate-400" />
-          <span className="text-slate-400 text-xs font-semibold uppercase tracking-widest">
+          <SlidersHorizontal className="w-3.5 h-3.5" style={{ color: B.faint }} />
+          <span className="text-xs font-semibold uppercase tracking-widest" style={{ color: B.faint }}>
             {t("sidebar.filters")}
           </span>
           {activeFilterCount > 0 && (
             <span
               className="ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-bold text-white"
-              style={{ background: "#0ea5e9" }}
+              style={{ background: B.gold }}
               data-testid="badge-filter-count"
             >
               {activeFilterCount}
@@ -151,18 +149,22 @@ export function MapSidebar() {
 
         {/* Property type */}
         <div>
-          <label className="block text-xs font-medium text-slate-400 mb-2">
+          <label className="block text-xs font-medium mb-2" style={{ color: B.muted }}>
             {t("filters.property_type")}
           </label>
           <select
             value={activeFilters.propertyType}
             onChange={(e) => updateFilters({ propertyType: e.target.value as PropertyType | "all" })}
             data-testid="select-property-type"
-            className="w-full rounded-lg px-3 py-2.5 text-sm text-slate-200 border border-slate-700 focus:outline-none focus:ring-1 focus:ring-sky-500 cursor-pointer"
-            style={{ background: "#1e293b" }}
+            className="w-full rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-1 cursor-pointer"
+            style={{
+              background: B.surface,
+              color:      B.navy,
+              border:     `1px solid ${B.border}`,
+            }}
           >
             {PROPERTY_TYPES.map((pt) => (
-              <option key={pt.value} value={pt.value} style={{ background: "#1e293b" }}>
+              <option key={pt.value} value={pt.value}>
                 {t(pt.tKey)}
               </option>
             ))}
@@ -171,7 +173,7 @@ export function MapSidebar() {
 
         {/* Price range */}
         <div>
-          <label className="block text-xs font-medium text-slate-400 mb-3">
+          <label className="block text-xs font-medium mb-3" style={{ color: B.muted }}>
             {t("filters.price_range")}
           </label>
           <PriceRangeSlider />
@@ -179,7 +181,7 @@ export function MapSidebar() {
 
         {/* Bedrooms */}
         <div>
-          <label className="block text-xs font-medium text-slate-400 mb-2">
+          <label className="block text-xs font-medium mb-2" style={{ color: B.muted }}>
             <span className="flex items-center gap-1.5">
               <BedDouble className="w-3.5 h-3.5" />
               {t("filters.min_bedrooms")}
@@ -193,9 +195,11 @@ export function MapSidebar() {
                 data-testid={`button-bedrooms-${opt.value}`}
                 className="flex-1 py-1.5 rounded-lg text-xs font-semibold transition-all duration-150"
                 style={{
-                  background: activeFilters.minBedrooms === opt.value ? "#0ea5e9" : "#1e293b",
-                  color: activeFilters.minBedrooms === opt.value ? "#fff" : "#94a3b8",
-                  border: activeFilters.minBedrooms === opt.value ? "1px solid #0ea5e9" : "1px solid #334155",
+                  background: activeFilters.minBedrooms === opt.value ? B.steel : B.surface,
+                  color:      activeFilters.minBedrooms === opt.value ? "#fff" : B.navy,
+                  border:     activeFilters.minBedrooms === opt.value
+                    ? `1px solid ${B.steel}`
+                    : `1px solid ${B.border}`,
                 }}
               >
                 {"labelKey" in opt ? t(opt.labelKey!) : opt.label}
@@ -214,15 +218,19 @@ export function MapSidebar() {
             <div className="relative w-10 h-5">
               <div
                 className="w-10 h-5 rounded-full transition-colors duration-200"
-                style={{ background: activeFilters.hasParking ? "#0ea5e9" : "#334155" }}
+                style={{ background: activeFilters.hasParking ? B.steel : B.element }}
               />
               <div
-                className="absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform duration-200"
-                style={{ transform: activeFilters.hasParking ? "translateX(21px)" : "translateX(2px)" }}
+                className="absolute top-0.5 w-4 h-4 rounded-full shadow transition-transform duration-200"
+                style={{
+                  background: "#fff",
+                  transform: activeFilters.hasParking ? "translateX(21px)" : "translateX(2px)",
+                  border: `1px solid ${B.border}`,
+                }}
               />
             </div>
-            <span className="flex items-center gap-1.5 text-sm text-slate-300">
-              <Car className="w-3.5 h-3.5 text-slate-400" />
+            <span className="flex items-center gap-1.5 text-sm" style={{ color: B.navy }}>
+              <Car className="w-3.5 h-3.5" style={{ color: B.faint }} />
               {t("filters.parking")}
             </span>
           </button>
@@ -248,8 +256,8 @@ export function MapSidebar() {
       </div>
 
       {/* Footer */}
-      <div className="px-6 py-4 border-t border-slate-700/60">
-        <p className="text-slate-500 text-xs text-center">Fortaleza · Ceará · Brasil</p>
+      <div className="px-6 py-4" style={{ borderTop: `1px solid ${B.border}` }}>
+        <p className="text-xs text-center" style={{ color: B.faint }}>Fortaleza · Ceará · Brasil</p>
       </div>
     </aside>
   );

--- a/artifacts/latitud/src/domains/map/components/NearbyPlaces.tsx
+++ b/artifacts/latitud/src/domains/map/components/NearbyPlaces.tsx
@@ -9,14 +9,15 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useMapStore } from "@/domains/map/store/map.store";
+import { B } from "./sidebarTheme";
 
 const PLACE_TYPES = [
-  { type: "restaurant", tKey: "nearby.restaurants", Icon: UtensilsCrossed, color: "#f97316" },
-  { type: "school",     tKey: "nearby.schools",     Icon: GraduationCap,   color: "#8b5cf6" },
-  { type: "hospital",   tKey: "nearby.hospitals",   Icon: Hospital,        color: "#ef4444" },
-  { type: "supermarket",tKey: "nearby.supermarkets",Icon: ShoppingCart,    color: "#10b981" },
-  { type: "gym",        tKey: "nearby.gyms",        Icon: Dumbbell,        color: "#3b82f6" },
-  { type: "bank",       tKey: "nearby.banks",       Icon: Landmark,        color: "#eab308" },
+  { type: "restaurant",  tKey: "nearby.restaurants", Icon: UtensilsCrossed, color: "#f97316" },
+  { type: "school",      tKey: "nearby.schools",     Icon: GraduationCap,   color: "#8b5cf6" },
+  { type: "hospital",    tKey: "nearby.hospitals",   Icon: Hospital,        color: "#ef4444" },
+  { type: "supermarket", tKey: "nearby.supermarkets",Icon: ShoppingCart,    color: "#10b981" },
+  { type: "gym",         tKey: "nearby.gyms",        Icon: Dumbbell,        color: B.steel   },
+  { type: "bank",        tKey: "nearby.banks",       Icon: Landmark,        color: B.gold    },
 ] as const;
 
 export function NearbyPlaces() {
@@ -30,7 +31,7 @@ export function NearbyPlaces() {
 
   return (
     <div>
-      <div className="flex items-center gap-2 text-slate-400 text-xs font-semibold uppercase tracking-widest mb-3">
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest mb-3" style={{ color: B.faint }}>
         <MapPin className="w-3.5 h-3.5" />
         <span>{t("sidebar.nearby_places")}</span>
       </div>
@@ -44,17 +45,17 @@ export function NearbyPlaces() {
               data-testid={`place-type-${type}`}
               className="flex flex-col items-center gap-1.5 px-2 py-2.5 rounded-xl text-center transition-all duration-150"
               style={{
-                background: active ? `${color}22` : "#1e293b",
-                border: active ? `1px solid ${color}66` : "1px solid #334155",
+                background: active ? `${color}18` : B.surface,
+                border:     active ? `1px solid ${color}55` : `1px solid ${B.border}`,
               }}
             >
               <Icon
                 className="w-4 h-4"
-                style={{ color: active ? color : "#64748b" }}
+                style={{ color: active ? color : B.muted }}
               />
               <span
                 className="text-[10px] font-medium leading-tight"
-                style={{ color: active ? color : "#64748b" }}
+                style={{ color: active ? color : B.muted }}
               >
                 {t(tKey)}
               </span>

--- a/artifacts/latitud/src/domains/map/components/RegionStats.tsx
+++ b/artifacts/latitud/src/domains/map/components/RegionStats.tsx
@@ -2,12 +2,13 @@ import { useTranslation } from "react-i18next";
 import { useMapStore } from "@/domains/map/store/map.store";
 import { formatBRL, calculateAverage, calculateMin, calculateMax } from "@/shared/utils/price.utils";
 import { BarChart3, TrendingDown, TrendingUp, Minus } from "lucide-react";
+import { B } from "./sidebarTheme";
 
 const TYPE_KEYS: Record<string, string> = {
   apartment: "filters.apartment",
-  house: "filters.house",
-  commercial: "filters.commercial",
-  office: "filters.office",
+  house:     "filters.house",
+  commercial:"filters.commercial",
+  office:    "filters.office",
 };
 
 export function RegionStats() {
@@ -27,16 +28,19 @@ export function RegionStats() {
   return (
     <div
       className="rounded-xl overflow-hidden"
-      style={{ background: "#1e293b", border: "1px solid #334155" }}
+      style={{ background: B.surface, border: `1px solid ${B.border}` }}
       data-testid="region-stats"
     >
       {/* Header */}
       <div
         className="px-4 py-3 flex items-center gap-2"
-        style={{ background: "rgba(99,102,241,0.12)", borderBottom: "1px solid #334155" }}
+        style={{
+          background:   `rgba(78,128,164,0.08)`,
+          borderBottom: `1px solid ${B.border}`,
+        }}
       >
-        <BarChart3 className="w-4 h-4 text-indigo-400" />
-        <span className="text-xs font-semibold text-indigo-300 uppercase tracking-widest">
+        <BarChart3 className="w-4 h-4" style={{ color: B.steel }} />
+        <span className="text-xs font-semibold uppercase tracking-widest" style={{ color: B.steel }}>
           Selected area
         </span>
       </div>
@@ -44,11 +48,8 @@ export function RegionStats() {
       <div className="px-4 py-3 space-y-3">
         {/* Total */}
         <div className="flex items-center justify-between">
-          <span className="text-xs text-slate-400">{t("stats.properties_found")}</span>
-          <span
-            className="text-sm font-bold text-white"
-            data-testid="stat-total"
-          >
+          <span className="text-xs" style={{ color: B.muted }}>{t("stats.properties_found")}</span>
+          <span className="text-sm font-bold" style={{ color: B.navy }} data-testid="stat-total">
             {filteredListings.length}
           </span>
         </div>
@@ -60,17 +61,18 @@ export function RegionStats() {
               <div className="space-y-1.5">
                 {Object.entries(byType).map(([type, count]) => (
                   <div key={type} className="flex items-center justify-between">
-                    <span className="text-xs text-slate-500">
+                    <span className="text-xs" style={{ color: B.faint }}>
                       {TYPE_KEYS[type] ? t(TYPE_KEYS[type]) : type}
                     </span>
                     <div className="flex items-center gap-2">
                       <div
-                        className="h-1 rounded-full bg-indigo-500 opacity-60"
+                        className="h-1 rounded-full opacity-60"
                         style={{
+                          background: B.steel,
                           width: `${Math.max(20, (count / filteredListings.length) * 60)}px`,
                         }}
                       />
-                      <span className="text-xs font-semibold text-slate-300 w-4 text-right">
+                      <span className="text-xs font-semibold w-4 text-right" style={{ color: B.muted }}>
                         {count}
                       </span>
                     </div>
@@ -79,34 +81,34 @@ export function RegionStats() {
               </div>
             )}
 
-            <div className="h-px" style={{ background: "#334155" }} />
+            <div className="h-px" style={{ background: B.border }} />
 
             {/* Price stats */}
             <div className="space-y-1.5">
               <div className="flex items-center justify-between">
-                <span className="flex items-center gap-1.5 text-xs text-slate-400">
+                <span className="flex items-center gap-1.5 text-xs" style={{ color: B.muted }}>
                   <Minus className="w-3 h-3" />
                   {t("stats.average_price")}
                 </span>
-                <span className="text-xs font-semibold text-slate-200" data-testid="stat-avg">
+                <span className="text-xs font-semibold" style={{ color: B.navy }} data-testid="stat-avg">
                   {formatBRL(Math.round(calculateAverage(prices)))}
                 </span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="flex items-center gap-1.5 text-xs text-slate-400">
-                  <TrendingDown className="w-3 h-3 text-emerald-400" />
+                <span className="flex items-center gap-1.5 text-xs" style={{ color: B.muted }}>
+                  <TrendingDown className="w-3 h-3 text-emerald-500" />
                   {t("stats.lowest_price")}
                 </span>
-                <span className="text-xs font-semibold text-emerald-400" data-testid="stat-min">
+                <span className="text-xs font-semibold text-emerald-600" data-testid="stat-min">
                   {formatBRL(calculateMin(prices))}
                 </span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="flex items-center gap-1.5 text-xs text-slate-400">
-                  <TrendingUp className="w-3 h-3 text-amber-400" />
+                <span className="flex items-center gap-1.5 text-xs" style={{ color: B.muted }}>
+                  <TrendingUp className="w-3 h-3 text-amber-500" />
                   {t("stats.highest_price")}
                 </span>
-                <span className="text-xs font-semibold text-amber-400" data-testid="stat-max">
+                <span className="text-xs font-semibold text-amber-600" data-testid="stat-max">
                   {formatBRL(calculateMax(prices))}
                 </span>
               </div>
@@ -115,7 +117,7 @@ export function RegionStats() {
         )}
 
         {filteredListings.length === 0 && (
-          <p className="text-xs text-slate-500 text-center py-2">
+          <p className="text-xs text-center py-2" style={{ color: B.faint }}>
             No properties in this area
           </p>
         )}

--- a/artifacts/latitud/src/domains/map/components/sidebarTheme.ts
+++ b/artifacts/latitud/src/domains/map/components/sidebarTheme.ts
@@ -1,0 +1,11 @@
+export const B = {
+  bg:      "#F7F6F2",
+  surface: "#FFFFFF",
+  element: "#EEF3F7",
+  border:  "#D4E2EB",
+  navy:    "#1C3456",
+  steel:   "#4E80A4",
+  gold:    "#C4973A",
+  muted:   "#6B8A9E",
+  faint:   "#8AABBD",
+} as const;

--- a/artifacts/latitud/src/index.css
+++ b/artifacts/latitud/src/index.css
@@ -68,41 +68,46 @@
 }
 
 :root {
-  --button-outline: rgba(0,0,0, .10);
-  --badge-outline: rgba(0,0,0, .05);
-  --opaque-button-border-intensity: -8;
-  --elevate-1: rgba(0,0,0, .03);
-  --elevate-2: rgba(0,0,0, .08);
+  --button-outline: rgba(0,0,0, .08);
+  --badge-outline: rgba(0,0,0, .04);
+  --opaque-button-border-intensity: -6;
+  --elevate-1: rgba(0,0,0, .025);
+  --elevate-2: rgba(0,0,0, .06);
 
-  --background: 210 20% 98%;
-  --foreground: 222 47% 11%;
-  --border: 220 13% 91%;
+  /* Brand palette — extracted from the Latitud compass logo */
+  --brand-navy:  #1C3456;   /* dark navy (compass needle, text)  */
+  --brand-steel: #4E80A4;   /* steel blue (ring bottom, primary) */
+  --brand-gold:  #C4973A;   /* warm gold (ring top, CTA accents) */
+
+  --background: 42 22% 97%;           /* ice white — warm off-white */
+  --foreground: 215 50% 22%;          /* dark navy */
+  --border: 205 22% 88%;              /* light blue-gray */
   --card: 0 0% 100%;
-  --card-foreground: 222 47% 11%;
-  --card-border: 220 13% 91%;
-  --sidebar: 222 47% 11%;
-  --sidebar-foreground: 210 20% 95%;
-  --sidebar-border: 217 33% 18%;
-  --sidebar-primary: 199 89% 48%;
+  --card-foreground: 215 50% 22%;
+  --card-border: 205 22% 88%;
+  --sidebar: 42 22% 97%;              /* ice white sidebar */
+  --sidebar-foreground: 215 50% 22%;
+  --sidebar-border: 205 22% 88%;
+  --sidebar-primary: 205 36% 47%;     /* steel blue */
   --sidebar-primary-foreground: 0 0% 100%;
-  --sidebar-accent: 217 33% 18%;
-  --sidebar-accent-foreground: 210 20% 95%;
-  --sidebar-ring: 199 89% 48%;
+  --sidebar-accent: 205 25% 93%;      /* light steel tint */
+  --sidebar-accent-foreground: 215 50% 22%;
+  --sidebar-ring: 205 36% 47%;
   --popover: 0 0% 100%;
-  --popover-foreground: 222 47% 11%;
-  --popover-border: 220 13% 91%;
-  --primary: 199 89% 48%;
+  --popover-foreground: 215 50% 22%;
+  --popover-border: 205 22% 88%;
+  --primary: 205 36% 47%;             /* steel blue */
   --primary-foreground: 0 0% 100%;
-  --secondary: 210 40% 96%;
-  --secondary-foreground: 222 47% 11%;
-  --muted: 210 40% 96%;
-  --muted-foreground: 215 16% 47%;
-  --accent: 210 40% 96%;
-  --accent-foreground: 222 47% 11%;
+  --secondary: 205 25% 93%;
+  --secondary-foreground: 215 50% 22%;
+  --muted: 205 25% 93%;
+  --muted-foreground: 205 20% 52%;
+  --accent: 205 25% 93%;
+  --accent-foreground: 215 50% 22%;
   --destructive: 0 84% 60%;
   --destructive-foreground: 0 0% 100%;
-  --input: 220 13% 91%;
-  --ring: 199 89% 48%;
+  --input: 205 22% 88%;
+  --ring: 205 36% 47%;
   --chart-1: 199 89% 48%;
   --chart-2: 160 60% 45%;
   --chart-3: 30 80% 55%;

--- a/artifacts/latitud/src/pages/LandingPage.tsx
+++ b/artifacts/latitud/src/pages/LandingPage.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "wouter";
 import { useTranslation } from "react-i18next";
 import { Map, useMap } from "react-map-gl/mapbox";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { MapPin, PencilLine, BarChart3, Compass, ArrowRight } from "lucide-react";
+import { PencilLine, BarChart3, Compass, ArrowRight } from "lucide-react";
 import { MAPBOX_TOKEN, HERO_MAP_STYLE } from "@/lib/mapbox";
 
 const PAN_TARGETS: [number, number][] = [
@@ -31,8 +31,9 @@ function AutoPanMap() {
   return null;
 }
 
+/* Brand accent colors used for feature cards */
 const FEATURE_ICONS = [PencilLine, BarChart3, Compass];
-const FEATURE_COLORS = ["#6366f1", "#0ea5e9", "#10b981"];
+const FEATURE_COLORS = ["#4E80A4", "#C4973A", "#1C3456"];
 
 export default function LandingPage() {
   const [, setLocation] = useLocation();
@@ -45,11 +46,11 @@ export default function LandingPage() {
   ];
 
   return (
-    <div className="min-h-screen bg-white font-sans">
-      {/* Hero */}
-      <section className="relative h-screen flex items-center justify-center overflow-hidden bg-slate-900">
+    <div className="min-h-screen font-sans" style={{ background: "#F7F6F2" }}>
+      {/* Hero — stays dark so the map reads well */}
+      <section className="relative h-screen flex items-center justify-center overflow-hidden" style={{ background: "#1C3456" }}>
         {/* Map background — desktop only */}
-        <div className="absolute inset-0 hidden md:block opacity-30">
+        <div className="absolute inset-0 hidden md:block opacity-25">
           {MAPBOX_TOKEN ? (
             <Map
               id="hero"
@@ -67,42 +68,34 @@ export default function LandingPage() {
               className="w-full h-full"
               style={{
                 background:
-                  "radial-gradient(ellipse at 60% 40%, #0ea5e920 0%, transparent 60%), radial-gradient(ellipse at 20% 70%, #6366f120 0%, transparent 50%)",
+                  "radial-gradient(ellipse at 60% 40%, #4E80A420 0%, transparent 60%), radial-gradient(ellipse at 20% 70%, #C4973A14 0%, transparent 50%)",
               }}
             />
           )}
         </div>
 
-        {/* Mobile gradient */}
-        <div
-          className="absolute inset-0 md:hidden"
-          style={{
-            background:
-              "radial-gradient(ellipse at 60% 30%, #0ea5e918 0%, transparent 60%), radial-gradient(ellipse at 10% 80%, #6366f118 0%, transparent 50%)",
-          }}
-        />
-
-        {/* Overlay for readability */}
+        {/* Gradient overlay for legibility */}
         <div
           className="absolute inset-0"
           style={{
             background:
-              "linear-gradient(to bottom, rgba(15,23,42,0.5) 0%, rgba(15,23,42,0.7) 60%, rgba(15,23,42,0.9) 100%)",
+              "linear-gradient(to bottom, rgba(28,52,86,0.55) 0%, rgba(28,52,86,0.75) 60%, rgba(28,52,86,0.92) 100%)",
           }}
         />
 
-        {/* Content */}
+        {/* Hero content */}
         <div
           className="relative z-10 text-center px-6 max-w-2xl mx-auto"
           style={{ animation: "fadeInUp 0.8s ease both" }}
         >
+          {/* Logo mark + wordmark */}
           <div className="flex items-center justify-center gap-3 mb-8">
-            <div
-              className="w-10 h-10 rounded-xl flex items-center justify-center shadow-lg"
-              style={{ background: "#0ea5e9" }}
-            >
-              <MapPin className="w-5 h-5 text-white" fill="white" />
-            </div>
+            <img
+              src="/assets/logo.svg"
+              alt="Latitud logo"
+              className="w-11 h-11"
+              style={{ filter: "brightness(0) invert(1)" }}
+            />
             <span className="text-3xl font-black text-white tracking-tight">
               Latitud
             </span>
@@ -121,8 +114,8 @@ export default function LandingPage() {
               data-testid="button-cta-explore"
               className="inline-flex items-center gap-2 px-8 py-4 rounded-2xl text-white font-bold text-lg transition-all duration-200 hover:scale-105 hover:shadow-xl"
               style={{
-                background: "#0ea5e9",
-                boxShadow: "0 8px 32px rgba(14,165,233,0.40)",
+                background: "#C4973A",
+                boxShadow: "0 8px 32px rgba(196,151,58,0.38)",
               }}
             >
               {t("landing.cta")}
@@ -131,7 +124,7 @@ export default function LandingPage() {
           </div>
         </div>
 
-        {/* Scroll indicator */}
+        {/* Scroll line */}
         <div
           className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 opacity-40"
           style={{ animation: "fadeInUp 0.8s ease 0.6s both" }}
@@ -144,13 +137,19 @@ export default function LandingPage() {
       </section>
 
       {/* Features */}
-      <section className="py-24 px-6 bg-white">
+      <section className="py-24 px-6" style={{ background: "#F7F6F2" }}>
         <div className="max-w-4xl mx-auto">
           <div className="grid md:grid-cols-3 gap-8">
             {features.map(({ Icon, title, desc, color }) => (
               <div
                 key={title}
-                className="group p-8 rounded-2xl border border-slate-100 hover:border-slate-200 hover:shadow-lg transition-all duration-200"
+                className="group p-8 rounded-2xl border transition-all duration-200"
+                style={{
+                  background: "#FFFFFF",
+                  borderColor: "#D4E2EB",
+                }}
+                onMouseEnter={e => (e.currentTarget.style.borderColor = color)}
+                onMouseLeave={e => (e.currentTarget.style.borderColor = "#D4E2EB")}
               >
                 <div
                   className="w-12 h-12 rounded-2xl flex items-center justify-center mb-5"
@@ -158,8 +157,8 @@ export default function LandingPage() {
                 >
                   <Icon className="w-6 h-6" style={{ color }} />
                 </div>
-                <h3 className="text-lg font-bold text-slate-900 mb-2">{title}</h3>
-                <p className="text-slate-500 text-sm leading-relaxed">{desc}</p>
+                <h3 className="text-lg font-bold mb-2" style={{ color: "#1C3456" }}>{title}</h3>
+                <p className="text-sm leading-relaxed" style={{ color: "#6B8A9E" }}>{desc}</p>
               </div>
             ))}
           </div>
@@ -168,7 +167,20 @@ export default function LandingPage() {
             <button
               onClick={() => setLocation("/map")}
               data-testid="button-cta-features"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl border-2 border-slate-200 text-slate-700 font-semibold text-sm hover:border-sky-400 hover:text-sky-600 transition-all duration-200"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl text-sm font-semibold transition-all duration-200"
+              style={{
+                border: "2px solid #D4E2EB",
+                color: "#4E80A4",
+                background: "transparent",
+              }}
+              onMouseEnter={e => {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "#C4973A";
+                (e.currentTarget as HTMLButtonElement).style.color = "#C4973A";
+              }}
+              onMouseLeave={e => {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "#D4E2EB";
+                (e.currentTarget as HTMLButtonElement).style.color = "#4E80A4";
+              }}
             >
               {t("nav.explore")}
               <ArrowRight className="w-4 h-4" />
@@ -178,8 +190,8 @@ export default function LandingPage() {
       </section>
 
       {/* Footer */}
-      <footer className="py-8 px-6 border-t border-slate-100 text-center">
-        <p className="text-slate-400 text-sm">
+      <footer className="py-8 px-6 text-center" style={{ borderTop: "1px solid #D4E2EB" }}>
+        <p className="text-sm" style={{ color: "#8AABBD" }}>
           © 2026 Latitud · Fortaleza, Ceará, Brasil
         </p>
       </footer>


### PR DESCRIPTION
- Add compass SVG logo (bicolor ring: gold + steel blue) to public/assets/
- Rebrand favicon with navy background and compass mark
- Replace generic placeholders with the real logo in LandingPage and MapSidebar
- Migrate sidebar from dark theme to ice-white (#F7F6F2) light theme
- Extract shared color tokens to sidebarTheme.ts to avoid circular imports
- Update CSS custom properties to use brand palette (navy, steel blue, gold)
- Set gold (#C4973A) as the primary CTA accent color
- Improve unselected button contrast: white background with navy text