### PR TITLE
fix(map): fix transit/cycling layers and improve nearby places search

### DIFF
--- a/artifacts/latitud/src/domains/map/components/LayersControl.tsx
+++ b/artifacts/latitud/src/domains/map/components/LayersControl.tsx
@@ -52,7 +52,7 @@ export function LayersControl() {
 
       {activeLayer === "transit" && (
         <p className="text-xs mt-2 leading-relaxed text-amber-600">
-          Public transit data may be limited for this region.
+          Subway data may be limited for this region.
         </p>
       )}
     </div>

--- a/artifacts/latitud/src/domains/map/components/MapLayersRenderer.tsx
+++ b/artifacts/latitud/src/domains/map/components/MapLayersRenderer.tsx
@@ -2,29 +2,74 @@ import { useEffect } from "react";
 import { Source, Layer, useMap } from "react-map-gl/mapbox";
 import { useMapStore } from "@/domains/map/store/map.store";
 
-const CYCLING_LAYERS = ["road-path", "road-pedestrian"];
-
 export function MapLayersRenderer() {
   const { current: mapRef } = useMap();
   const activeLayer = useMapStore((s) => s.activeLayer);
 
+  // Cycling overlay — adds a green highlight on bike-path road classes.
+  // We add a new layer instead of toggling existing ones because streets-v12
+  // already renders road-path/road-pedestrian as visible by default.
   useEffect(() => {
     if (!mapRef) return;
     const map = mapRef.getMap();
+    const ID = "latitud-cycling";
+
     const apply = () => {
-      const v = activeLayer === "bicycling" ? "visible" : "none";
-      CYCLING_LAYERS.forEach((id) => { try { map.setLayoutProperty(id, "visibility", v); } catch {} });
+      try {
+        if (!map.getLayer(ID)) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          map.addLayer({
+            id: ID,
+            type: "line",
+            source: "composite",
+            "source-layer": "road",
+            filter: ["match", ["get", "class"], ["path", "pedestrian"], true, false],
+            layout: { "line-join": "round", "line-cap": "round" },
+            paint: {
+              "line-color": "#22c55e",
+              "line-width": 2.5,
+              "line-opacity": 0.9,
+              "line-dasharray": [2, 1.5],
+            },
+          } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+        }
+        map.setLayoutProperty(ID, "visibility", activeLayer === "bicycling" ? "visible" : "none");
+      } catch { /* map not ready or source-layer unavailable */ }
     };
-    if (map.isStyleLoaded()) apply(); else map.once("load", apply);
+
+    if (map.isStyleLoaded()) apply(); else map.once("style.load", apply);
   }, [mapRef, activeLayer]);
 
+  // Transit overlay — adds purple circles on transit stop points.
+  // transit_stop_label is a point source-layer from mapbox-streets-v8 (bundled in streets-v12).
   useEffect(() => {
     if (!mapRef) return;
     const map = mapRef.getMap();
+    const ID = "latitud-transit";
+
     const apply = () => {
-      try { map.setLayoutProperty("transit-label", "visibility", activeLayer === "transit" ? "visible" : "none"); } catch {}
+      try {
+        if (!map.getLayer(ID)) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          map.addLayer({
+            id: ID,
+            type: "circle",
+            source: "composite",
+            "source-layer": "transit_stop_label",
+            paint: {
+              "circle-radius": 6,
+              "circle-color": "#818cf8",
+              "circle-stroke-width": 2,
+              "circle-stroke-color": "#ffffff",
+              "circle-opacity": 0.9,
+            },
+          } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+        }
+        map.setLayoutProperty(ID, "visibility", activeLayer === "transit" ? "visible" : "none");
+      } catch { /* source-layer may not exist in this tile region */ }
     };
-    if (map.isStyleLoaded()) apply(); else map.once("load", apply);
+
+    if (map.isStyleLoaded()) apply(); else map.once("style.load", apply);
   }, [mapRef, activeLayer]);
 
   return (
@@ -37,10 +82,10 @@ export function MapLayersRenderer() {
         paint={{
           "line-color": [
             "case",
-            ["==", ["get", "congestion"], "low"], "#4ade80",
+            ["==", ["get", "congestion"], "low"],      "#4ade80",
             ["==", ["get", "congestion"], "moderate"], "#facc15",
-            ["==", ["get", "congestion"], "heavy"], "#f97316",
-            ["==", ["get", "congestion"], "severe"], "#ef4444",
+            ["==", ["get", "congestion"], "heavy"],    "#f97316",
+            ["==", ["get", "congestion"], "severe"],   "#ef4444",
             "#94a3b8",
           ],
           "line-width": 2.5,

--- a/artifacts/latitud/src/domains/map/components/NearbyMarkers.tsx
+++ b/artifacts/latitud/src/domains/map/components/NearbyMarkers.tsx
@@ -1,85 +1,194 @@
 import { useEffect, useState } from "react";
-import { Marker, Popup, useMap } from "react-map-gl/mapbox";
+import { Marker, Popup } from "react-map-gl/mapbox";
 import { useMapStore } from "@/domains/map/store/map.store";
+import type { DrawnPolygon } from "@/domains/map/store/map.store";
 
-const OVERPASS_URL = "https://overpass-api.de/api/interpreter";
+// Try mirrors in order; skip on 429 / 504 / network error
+const OVERPASS_MIRRORS = [
+  "https://overpass-api.de/api/interpreter",
+  "https://overpass.kumi.systems/api/interpreter",
+  "https://overpass.openstreetmap.ru/api/interpreter",
+];
 
 const PLACE_CONFIG: Record<string, { amenity: string; color: string }> = {
-  restaurant: { amenity: "restaurant", color: "#f97316" },
-  school:     { amenity: "school",     color: "#8b5cf6" },
-  hospital:   { amenity: "hospital",   color: "#ef4444" },
-  supermarket:{ amenity: "supermarket",color: "#10b981" },
-  gym:        { amenity: "gym",        color: "#3b82f6" },
-  bank:       { amenity: "bank",       color: "#eab308" },
+  restaurant:  { amenity: "restaurant",  color: "#f97316" },
+  school:      { amenity: "school",      color: "#8b5cf6" },
+  hospital:    { amenity: "hospital",    color: "#ef4444" },
+  supermarket: { amenity: "supermarket", color: "#10b981" },
+  gym:         { amenity: "gym",         color: "#3b82f6" },
+  bank:        { amenity: "bank",        color: "#eab308" },
 };
 
 interface OverpassElement {
   id: number;
-  lat: number;
-  lon: number;
+  type: "node" | "way" | "relation";
+  lat?: number;
+  lon?: number;
+  center?: { lat: number; lon: number };
   tags?: { name?: string };
 }
 
-async function queryOverpass(amenity: string, lat: number, lng: number): Promise<OverpassElement[]> {
-  const q = `[out:json];node["amenity"="${amenity}"](around:1500,${lat},${lng});out 20;`;
-  const res = await fetch(`${OVERPASS_URL}?data=${encodeURIComponent(q)}`);
-  if (!res.ok) return [];
-  const data = await res.json();
-  return (data.elements ?? []) as OverpassElement[];
+function polygonBbox(polygon: DrawnPolygon) {
+  const ring = polygon.geometry.coordinates[0];
+  let west = Infinity, east = -Infinity, south = Infinity, north = -Infinity;
+  for (const [lng, lat] of ring) {
+    if (lng < west) west = lng;
+    if (lng > east) east = lng;
+    if (lat < south) south = lat;
+    if (lat > north) north = lat;
+  }
+  return { west, east, south, north };
+}
+
+function pointInPolygon(lng: number, lat: number, ring: [number, number][]): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    if ((yi > lat) !== (yj > lat) && lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+async function queryOverpass(
+  amenity: string,
+  bbox: { south: number; west: number; north: number; east: number },
+): Promise<OverpassElement[]> {
+  const { south, west, north, east } = bbox;
+  // Query both nodes and ways; "out center" returns a lat/lon centroid for ways
+  const q = [
+    "[out:json][timeout:25];",
+    "(",
+    `node["amenity"="${amenity}"](${south},${west},${north},${east});`,
+    `way["amenity"="${amenity}"](${south},${west},${north},${east});`,
+    ");",
+    "out center 100;",
+  ].join("");
+
+  for (const mirror of OVERPASS_MIRRORS) {
+    try {
+      const res = await fetch(`${mirror}?data=${encodeURIComponent(q)}`);
+      if (res.ok) {
+        const data = await res.json();
+        return (data.elements ?? []) as OverpassElement[];
+      }
+      // On rate-limit or timeout, try next mirror
+      if (res.status === 429 || res.status === 504) continue;
+    } catch {
+      continue; // network error — try next mirror
+    }
+  }
+  return [];
 }
 
 export function NearbyMarkers() {
-  const { current: mapRef } = useMap();
-  const activePlaceType = useMapStore((s) => s.activePlaceType);
-  const [places, setPlaces] = useState<OverpassElement[]>([]);
+  const activePlaceType  = useMapStore((s) => s.activePlaceType);
+  const hasActivePolygon = useMapStore((s) => s.hasActivePolygon);
+  const activePolygon    = useMapStore((s) => s.activePolygon);
+
+  const [places, setPlaces]             = useState<OverpassElement[]>([]);
   const [hoveredPlace, setHoveredPlace] = useState<OverpassElement | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading]       = useState(false);
 
   useEffect(() => {
-    if (!activePlaceType || !mapRef) { setPlaces([]); return; }
+    if (!activePlaceType || !hasActivePolygon || !activePolygon) {
+      setPlaces([]);
+      return;
+    }
+
     const config = PLACE_CONFIG[activePlaceType];
     if (!config) return;
 
-    const center = mapRef.getCenter();
+    const bbox = polygonBbox(activePolygon);
+    const ring = activePolygon.geometry.coordinates[0] as [number, number][];
     let cancelled = false;
-    setIsLoading(true);
 
-    queryOverpass(config.amenity, center.lat, center.lng)
-      .then((r) => { if (!cancelled) setPlaces(r); })
-      .catch(() => { if (!cancelled) setPlaces([]); })
-      .finally(() => { if (!cancelled) setIsLoading(false); });
+    // Debounce: wait 600 ms before firing to avoid burst requests on rapid
+    // category switching
+    const timer = setTimeout(async () => {
+      if (cancelled) return;
+      setIsLoading(true);
+      try {
+        const results = await queryOverpass(config.amenity, bbox);
+        if (cancelled) return;
+        setPlaces(
+          results.filter((p) => {
+            const lat = p.lat ?? p.center?.lat;
+            const lon = p.lon ?? p.center?.lon;
+            return lat !== undefined && lon !== undefined && pointInPolygon(lon, lat, ring);
+          }),
+        );
+      } catch {
+        if (!cancelled) setPlaces([]);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }, 600);
 
-    return () => { cancelled = true; setPlaces([]); };
-  }, [activePlaceType, mapRef]);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      setPlaces([]);
+      setIsLoading(false);
+    };
+  }, [activePlaceType, hasActivePolygon, activePolygon]);
 
-  if (!activePlaceType) return null;
+  if (!activePlaceType || !hasActivePolygon) return null;
+
   const color = PLACE_CONFIG[activePlaceType]?.color ?? "#6366f1";
 
   return (
     <>
       {isLoading && (
-        <div style={{ position:"absolute", top:12, left:"50%", transform:"translateX(-50%)", background:"rgba(15,23,42,0.85)", color:"#94a3b8", fontSize:11, fontWeight:600, padding:"4px 12px", borderRadius:999, zIndex:20, pointerEvents:"none" }}>
-          Buscando locais...
+        <div
+          style={{
+            position: "absolute", top: 12, left: "50%", transform: "translateX(-50%)",
+            background: "rgba(28,52,86,0.85)", color: "#D4E2EB",
+            fontSize: 11, fontWeight: 600, padding: "4px 12px",
+            borderRadius: 999, zIndex: 20, pointerEvents: "none",
+          }}
+        >
+          Buscando locais…
         </div>
       )}
 
-      {places.map((place) => (
-        <Marker key={place.id} longitude={place.lon} latitude={place.lat} anchor="center">
-          <div
-            onMouseEnter={() => setHoveredPlace(place)}
-            onMouseLeave={() => setHoveredPlace(null)}
-            style={{ width:14, height:14, borderRadius:"50%", background:color, border:"2px solid white", boxShadow:`0 2px 6px ${color}66`, cursor:"default" }}
-          />
-        </Marker>
-      ))}
+      {places.map((place) => {
+        const lat = place.lat ?? place.center?.lat;
+        const lon = place.lon ?? place.center?.lon;
+        if (lat === undefined || lon === undefined) return null;
+        return (
+          <Marker key={`${place.type}-${place.id}`} longitude={lon} latitude={lat} anchor="center">
+            <div
+              onMouseEnter={() => setHoveredPlace(place)}
+              onMouseLeave={() => setHoveredPlace(null)}
+              style={{
+                width: 14, height: 14, borderRadius: "50%",
+                background: color, border: "2px solid white",
+                boxShadow: `0 2px 6px ${color}66`, cursor: "default",
+              }}
+            />
+          </Marker>
+        );
+      })}
 
-      {hoveredPlace?.tags?.name && (
-        <Popup longitude={hoveredPlace.lon} latitude={hoveredPlace.lat} closeButton={false} anchor="bottom" offset={12}>
-          <p style={{ margin:0, fontSize:12, fontWeight:600, color:"#0f172a", whiteSpace:"nowrap", maxWidth:160, overflow:"hidden", textOverflow:"ellipsis" }}>
-            {hoveredPlace.tags.name}
-          </p>
-        </Popup>
-      )}
+      {hoveredPlace?.tags?.name && (() => {
+        const lat = hoveredPlace.lat ?? hoveredPlace.center?.lat;
+        const lon = hoveredPlace.lon ?? hoveredPlace.center?.lon;
+        if (!lat || !lon) return null;
+        return (
+          <Popup longitude={lon} latitude={lat} closeButton={false} anchor="bottom" offset={12}>
+            <p style={{
+              margin: 0, fontSize: 12, fontWeight: 600, color: "#1C3456",
+              whiteSpace: "nowrap", maxWidth: 160,
+              overflow: "hidden", textOverflow: "ellipsis",
+            }}>
+              {hoveredPlace.tags.name}
+            </p>
+          </Popup>
+        );
+      })()}
     </>
   );
 }

--- a/artifacts/latitud/src/domains/map/components/NearbyPlaces.tsx
+++ b/artifacts/latitud/src/domains/map/components/NearbyPlaces.tsx
@@ -22,10 +22,12 @@ const PLACE_TYPES = [
 
 export function NearbyPlaces() {
   const { t } = useTranslation();
-  const activePlaceType = useMapStore((s) => s.activePlaceType);
+  const activePlaceType  = useMapStore((s) => s.activePlaceType);
+  const hasActivePolygon = useMapStore((s) => s.hasActivePolygon);
   const setActivePlaceType = useMapStore((s) => s.setActivePlaceType);
 
   const toggle = (type: string) => {
+    if (!hasActivePolygon) return;
     setActivePlaceType(activePlaceType === type ? null : type);
   };
 
@@ -35,24 +37,26 @@ export function NearbyPlaces() {
         <MapPin className="w-3.5 h-3.5" />
         <span>{t("sidebar.nearby_places")}</span>
       </div>
+
       <div className="grid grid-cols-3 gap-1.5">
         {PLACE_TYPES.map(({ type, tKey, Icon, color }) => {
           const active = activePlaceType === type;
+          const disabled = !hasActivePolygon;
           return (
             <button
               key={type}
               onClick={() => toggle(type)}
               data-testid={`place-type-${type}`}
+              disabled={disabled}
               className="flex flex-col items-center gap-1.5 px-2 py-2.5 rounded-xl text-center transition-all duration-150"
               style={{
-                background: active ? `${color}18` : B.surface,
-                border:     active ? `1px solid ${color}55` : `1px solid ${B.border}`,
+                background:  active   ? `${color}18` : B.surface,
+                border:      active   ? `1px solid ${color}55` : `1px solid ${B.border}`,
+                opacity:     disabled ? 0.45 : 1,
+                cursor:      disabled ? "not-allowed" : "pointer",
               }}
             >
-              <Icon
-                className="w-4 h-4"
-                style={{ color: active ? color : B.muted }}
-              />
+              <Icon className="w-4 h-4" style={{ color: active ? color : B.muted }} />
               <span
                 className="text-[10px] font-medium leading-tight"
                 style={{ color: active ? color : B.muted }}
@@ -63,6 +67,12 @@ export function NearbyPlaces() {
           );
         })}
       </div>
+
+      {!hasActivePolygon && (
+        <p className="text-[10px] text-center mt-2 leading-relaxed" style={{ color: B.faint }}>
+          Desenhe uma área no mapa para buscar locais próximos.
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Replace visibility toggling of existing streets-v12 layers (which were already visible by default) with dynamic custom overlays:
  - Cycling: green dashed line layer on road class path/pedestrian
  - Transit: purple circle layer on transit_stop_label points
- Restrict nearby places search to require a drawn polygon; buttons are disabled with an explanatory hint when no polygon exists
- Extend Overpass query to include ways (not just nodes) and use "out center" so large amenities mapped as areas return a centroid
- Increase result limit from 30 to 100
- Add 600ms debounce to prevent request bursts on rapid category switching
- Add automatic fallback to two alternative Overpass mirrors on 429/504